### PR TITLE
[Add] 긴 텍스트 feed fold 구현 #33

### DIFF
--- a/client/src/composition/Feed/FeedBody.tsx
+++ b/client/src/composition/Feed/FeedBody.tsx
@@ -1,30 +1,78 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useRef } from 'react';
+import styled, { css } from 'styled-components';
 import ImageContainer from './ImageContainer';
 import { Image } from 'react-components.d';
+import { useState } from 'react';
+import { useEffect } from 'react';
 
 const FeedContents = styled.div`
   margin-top: 6px;
   padding-bottom: 14px;
 `;
 
-const FeedText = styled.div`
+const FeedText = styled.div<Sprops>`
   font-size: 14px;
   font-weight: normal;
   line-height: 1.38;
   word-break: break-word;
   white-space: pre-wrap;
   word-wrap: break-word;
+  text-overflow: ellipsis;
+  ${props => (props.isfold ? foldOn : 'display: inline-block;')}
+  max-height: 302px;
 `;
+const foldOn = css`
+  overflow: hidden;
+  -webkit-line-clamp: 16;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+`;
+
+const ReadMore = styled.span`
+  color: #385898;
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+interface Sprops {
+  isfold: boolean;
+}
 
 interface Iprops {
   content: string | null | undefined;
   images: (Image | null)[] | null | undefined;
 }
+
+const FEED_MAX_HEIGHT = 300;
 const FeedBody = ({ content, images }: Iprops) => {
+  const [isFold, setIsFold] = useState<boolean>(true);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const spreadFold = () => {
+    setIsFold(false);
+  };
+
+  const checkContentSize = () => {
+    return (
+      contentRef &&
+      contentRef.current &&
+      contentRef.current.clientHeight < FEED_MAX_HEIGHT
+    );
+  };
+
+  useEffect(() => {
+    if (checkContentSize()) {
+      setIsFold(false);
+    }
+  }, [contentRef]);
+
   return (
     <FeedContents>
-      <FeedText>{content}</FeedText>
+      <FeedText ref={contentRef} isfold={isFold}>
+        {content}
+      </FeedText>
+      {isFold && <ReadMore onClick={spreadFold}>더 보기</ReadMore>}
       {images && images.length > 0 && <ImageContainer images={images} />}
     </FeedContents>
   );


### PR DESCRIPTION
### 개발사항
텍스트가 긴 경우
- 말줄임표로 텍스트가 줄어든다
- 더보기 버튼이  나타나고
- 더보기 버튼 클릭시 나머지 글 확인 가능

### 개발
- useRef로 컨텐츠 길이를 확인하고 더보기 여부 결정
- 말줄임표는 텍스트 폰트 기준 16줄까지 표시가 되므로 16줄에서 말줄임표 표시하도록 설정

### 주의
말줄임표는 지원되는 브라우저가 제한이 있음
`-webkit-line-clamp: 16;`
`display: -webkit-box;`