### PR TITLE
[박상은]w6_리뷰요청_친구알람 기능 추가

### DIFF
--- a/client/src/composition/Header/FriendTab/ButtonContainer.tsx
+++ b/client/src/composition/Header/FriendTab/ButtonContainer.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import ActionButton from 'components/ActionButton';
+import Button from 'components/Button';
+import styled from 'styled-components';
+import {
+  useRequestFriendMutation,
+  useRejectFriendRequestMutation
+} from 'react-components.d';
+
+const OkButtonDiv = styled.div<IDiv>`
+  display: ${props => (props.isFriend ? 'none' : 'block')};
+  margin-right: 10px;
+`;
+
+interface IProps {
+  email: string;
+}
+
+interface IDiv {
+  isFriend: boolean;
+}
+
+function ButtonContainer({ email }: IProps) {
+  const [isFriend, setIsFriend] = useState(false);
+  const [acceptFriend] = useRequestFriendMutation();
+  const [rejectFriend] = useRejectFriendRequestMutation();
+
+  function sendRequest(e: React.MouseEvent<HTMLButtonElement>) {
+    e.preventDefault();
+
+    acceptFriend({ variables: { email, relation: 'REQUESTED_FROM' } });
+    setIsFriend(true);
+  }
+
+  function rejectRequest(e: React.MouseEvent<HTMLButtonElement>) {
+    e.preventDefault();
+
+    rejectFriend({ variables: { email } });
+  }
+
+  return (
+    <>
+      <OkButtonDiv isFriend={isFriend}>
+        <Button text="확인" onClick={sendRequest} size="small"></Button>
+      </OkButtonDiv>
+      <ActionButton
+        text={isFriend ? '친구' : '삭제'}
+        onClick={rejectRequest}></ActionButton>
+    </>
+  );
+}
+
+export default ButtonContainer;

--- a/client/src/composition/Header/FriendTab/FriendRequestContainer.tsx
+++ b/client/src/composition/Header/FriendTab/FriendRequestContainer.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import ButtonContainer from 'composition/Header/FriendTab/ButtonContainer';
+import { useEffect } from 'react';
+import FriendBox from './FriendBox';
+import { ALARM_SUBSCRIPTION, GET_REC_ALARM } from './friend.query';
+import { useRequestAlarmQuery, FriendAlarmUser } from 'react-components.d';
+import { useHeaderTabCountDispatch } from 'stores/HeaderTabCountContext';
+import client from 'apollo/ApolloClient';
+import { immutableSplice } from 'utils/immutable';
+import { IRequestAlarm, ISubscription } from 'schema/Header/friendTab';
+
+function removeDuplicationFromRecommendList(newAlarmItem: FriendAlarmUser) {
+  const recommendAlarm = client.readQuery({ query: GET_REC_ALARM })
+    .recommendAlarm;
+
+  const idx = recommendAlarm.findIndex(
+    (alarm: FriendAlarmUser) => alarm.email === newAlarmItem.email
+  );
+
+  if (idx !== -1) {
+    client.writeQuery({
+      query: GET_REC_ALARM,
+      data: {
+        recommendAlarm: immutableSplice(idx, recommendAlarm)
+      }
+    });
+  }
+}
+
+function FriendRequestContainer() {
+  const { subscribeToMore, data, loading }: any = useRequestAlarmQuery();
+  const headerTabCountDispatch = useHeaderTabCountDispatch();
+
+  useEffect(() => {
+    subscribeToMore({
+      document: ALARM_SUBSCRIPTION,
+      updateQuery: (
+        prev: IRequestAlarm,
+        { subscriptionData: { data } }: ISubscription
+      ) => {
+        if (!data) return prev;
+
+        const { requestAlarmAdded: newAlarmItem } = data;
+
+        if (newAlarmItem.action === 'ADDED') {
+          headerTabCountDispatch({
+            type: 'ADD_FRIEND_CNT',
+            key: { id: 'friendCount', value: 1 }
+          });
+
+          removeDuplicationFromRecommendList(newAlarmItem);
+
+          return Object.assign({}, prev, {
+            requestAlarm: [newAlarmItem, ...prev.requestAlarm]
+          });
+        } else {
+          headerTabCountDispatch({
+            type: 'ADD_FRIEND_CNT',
+            key: { id: 'friendCount', value: -1 }
+          });
+
+          const idx = prev.requestAlarm.findIndex(
+            alarm => alarm.email === newAlarmItem.email
+          );
+
+          return Object.assign({}, prev, {
+            requestAlarm: immutableSplice(idx, prev.requestAlarm)
+          });
+        }
+      }
+    });
+  }, [subscribeToMore]);
+
+  return (
+    <>
+      {!loading &&
+        data.requestAlarm.map(
+          ({ nickname, email, thumbnail }: FriendAlarmUser) => (
+            <FriendBox nickname={nickname} key={email} imageUrl={thumbnail}>
+              <ButtonContainer email={email} />
+            </FriendBox>
+          )
+        )}
+    </>
+  );
+}
+
+export default FriendRequestContainer;

--- a/client/src/composition/Header/FriendTab/FriendTabPresenter.tsx
+++ b/client/src/composition/Header/FriendTab/FriendTabPresenter.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components';
+import CommonHeader from '../CommonHeader';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+`;
+
+const Header = styled(CommonHeader)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+`;
+
+const RecentText = styled.span`
+  color: rgba(0, 0, 0, 0.8);
+  font-weight: 600;
+`;
+
+interface IProps {
+  text: string;
+}
+
+function FriendTabPresenter({ text }: IProps) {
+  return (
+    <Container>
+      <Header>
+        <RecentText>{text}</RecentText>
+      </Header>
+    </Container>
+  );
+}
+
+export default FriendTabPresenter;

--- a/client/src/composition/Header/FriendTab/NewFriendAlarmNum.tsx
+++ b/client/src/composition/Header/FriendTab/NewFriendAlarmNum.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from 'styled-components';
+import {
+  useHeaderTabCountState,
+} from 'stores/HeaderTabCountContext';
+
+const NewAlarmNumContainer = styled.span`
+  display: flex;
+  position: absolute;
+  top: -3px;
+  right: -8px;
+`;
+
+const NewAlarmNumIcon = styled.span`
+  background-color: #fa3e3e;
+  border-radius: 2px;
+  color: #fff;
+  padding: 1px 3px;
+  font-size: 10px;
+`;
+
+function NewFriendAlarmNum() {
+  const headerTabCountState = useHeaderTabCountState();
+
+  if (headerTabCountState.friendCount <= 0) return <></>;
+
+  return (
+    <NewAlarmNumContainer>
+      <NewAlarmNumIcon>{headerTabCountState.friendCount}</NewAlarmNumIcon>
+    </NewAlarmNumContainer>
+  );
+}
+
+export default NewFriendAlarmNum;

--- a/client/src/composition/Header/FriendTab/index.tsx
+++ b/client/src/composition/Header/FriendTab/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components';
+import FriendRequestContainer from './FriendRequestContainer';
+import FriendRecommendContainer from './FriendRecommendContainer';
+import FriendTabPresenter from './FriendTabPresenter';
+import { useHeaderTabCountDispatch } from 'stores/HeaderTabCountContext';
+import { useChangeAllRequestReadStateMutation } from 'react-components.d';
+import { useEffect } from 'react';
+
+const Header = styled.div``;
+
+interface IProps {
+  selected: boolean;
+}
+
+function FriendTab({ selected }: IProps) {
+  const headerTabCountDispatch = useHeaderTabCountDispatch();
+  const [changeReadState] = useChangeAllRequestReadStateMutation();
+
+  useEffect(() => {
+    if (selected) {
+      changeReadState();
+      headerTabCountDispatch({
+        type: 'RESET_FRIEND_CNT'
+      });
+    }
+  }, [selected]);
+
+  return (
+    <Header>
+      <FriendTabPresenter text="친구 요청" />
+      <FriendRequestContainer />
+      <FriendTabPresenter text="알 수도 있는 사람" />
+      <FriendRecommendContainer />
+    </Header>
+  );
+}
+
+export default FriendTab;

--- a/server/src/api/friend/friend.graphql
+++ b/server/src/api/friend/friend.graphql
@@ -1,0 +1,29 @@
+type FriendAlarmUser {
+  nickname: String!
+  thumbnail: String
+  email: String!
+  targetEmail: String
+  action: String
+}
+
+type FriendAlarmNum {
+  difference: Int
+  targetEmail: String
+}
+
+type Mutation {
+  requestFriend(targetEmail: String!, relation: String!): Boolean!
+  rejectFriendRequest(targetEmail: String!): Boolean!
+  changeAllRequestReadState: Boolean!
+}
+
+type Query {
+  requestAlarm: [FriendAlarmUser]
+  recommendAlarm: [FriendAlarmUser]
+  friendUnreadAlarmNum: Int!
+}
+
+type Subscription {
+  requestAlarmAdded: FriendAlarmUser
+  friendAlarmNumChanged: FriendAlarmNum
+}

--- a/server/src/api/friend/friend.resolvers.ts
+++ b/server/src/api/friend/friend.resolvers.ts
@@ -1,0 +1,120 @@
+import { MutationRequestFriendArgs } from '../../types';
+import { requestDB } from '../../utils/requestDB';
+import {
+  SEND_FRIEND_REQUEST_BY_EMAIL,
+  ACCEPT_FRIEND_REQUEST_BY_EMAIL,
+  CANCEL_FRIEND_REQUEST_BY_EMAIL,
+  CANCEL_FRIEND_BY_EMAIL,
+  FIND_USER_BY_REQUEST_RELATION,
+  FIND_USER_BY_NO_RELATION,
+  REJECT_FRIEND_REQUEST_BY_EMAIL
+} from '../../schema/friend/query';
+import { FIND_USER_WITH_EMAIL_QUERY } from '../../schema/user/query';
+import isAuthenticated from '../../utils/isAuthenticated';
+import { parseResultRecords, gatherValuesByKey } from '../../utils/parseData';
+
+const REQUEST_ALARM_ADDED = 'REQUEST_ALARM_ADDED';
+
+function getQueryByRelation(relation: string) {
+  switch (relation) {
+    case 'NONE':
+      return SEND_FRIEND_REQUEST_BY_EMAIL;
+    case 'REQUEST':
+      return CANCEL_FRIEND_REQUEST_BY_EMAIL;
+    case 'REQUESTED_FROM':
+      return ACCEPT_FRIEND_REQUEST_BY_EMAIL;
+    default:
+      return CANCEL_FRIEND_BY_EMAIL;
+  }
+}
+
+async function getUserInfoByEmail(email: string) {
+  const user = await requestDB(FIND_USER_WITH_EMAIL_QUERY, { email });
+  return user[0].get(0).properties;
+}
+
+export default {
+  Query: {
+    requestAlarm: async (_, __, { req }) => {
+      isAuthenticated(req);
+
+      const reqUsers = await requestDB(FIND_USER_BY_REQUEST_RELATION, {
+        email: req.email
+      });
+
+      const parsedReq = parseResultRecords(reqUsers);
+
+      return gatherValuesByKey(parsedReq, 'user');
+    },
+    recommendAlarm: async (_, __, { req }) => {
+      isAuthenticated(req);
+
+      const recUsers = await requestDB(FIND_USER_BY_NO_RELATION, {
+        email: req.email
+      });
+
+      const parsedRec = parseResultRecords(recUsers);
+
+      return gatherValuesByKey(parsedRec, 'target');
+    }
+  },
+
+  Mutation: {
+    requestFriend: async (
+      _,
+      { targetEmail, relation }: MutationRequestFriendArgs,
+      { req, pubsub }
+    ) => {
+      isAuthenticated(req);
+
+      await requestDB(getQueryByRelation(relation), {
+        email: req.email,
+        targetEmail
+      });
+
+      if (relation === 'NONE') {
+        const user = await getUserInfoByEmail(req.email);
+
+        pubsub.publish(REQUEST_ALARM_ADDED, {
+          requestAlarmAdded: {
+            ...user,
+            targetEmail,
+            action: 'ADDED'
+          }
+        });
+      } else if (relation === 'REQUEST') {
+        const user = await getUserInfoByEmail(req.email);
+
+        pubsub.publish(REQUEST_ALARM_ADDED, {
+          requestAlarmAdded: {
+            ...user,
+            targetEmail,
+            action: 'DELETED'
+          }
+        });
+      }
+
+      return true;
+    },
+
+    rejectFriendRequest: async (_, { targetEmail }, { req, pubsub }) => {
+      isAuthenticated(req);
+
+      await requestDB(REJECT_FRIEND_REQUEST_BY_EMAIL, {
+        email: req.email,
+        targetEmail
+      });
+
+      pubsub.publish(REQUEST_ALARM_ADDED, {
+        requestAlarmAdded: {
+          nickname: 'deletedUser',
+          email: targetEmail,
+          targetEmail: req.email,
+          action: 'DELETED'
+        }
+      });
+
+      return true;
+    }
+  }
+};

--- a/server/src/api/friend/friendAlarm.resolvers.ts
+++ b/server/src/api/friend/friendAlarm.resolvers.ts
@@ -1,0 +1,47 @@
+import { requestDB } from '../../utils/requestDB';
+import {
+  CHANGE_ALL_REQUEST_READ_STATE_BY_EMAIL,
+  COUNT_UNREAD_REQUEST_BY_EMAIL
+} from '../../schema/friend/query';
+import isAuthenticated from '../../utils/isAuthenticated';
+import { withFilter } from 'graphql-subscriptions';
+
+const REQUEST_ALARM_ADDED = 'REQUEST_ALARM_ADDED';
+
+export default {
+  Query: {
+    friendUnreadAlarmNum: async (_, __, { req }) => {
+      isAuthenticated(req);
+
+      const countRes = await requestDB(COUNT_UNREAD_REQUEST_BY_EMAIL, {
+        email: req.email
+      });
+
+      return String(countRes[0].get(0));
+    }
+  },
+
+  Mutation: {
+    changeAllRequestReadState: async (_, __, { req }) => {
+      isAuthenticated(req);
+
+      await requestDB(CHANGE_ALL_REQUEST_READ_STATE_BY_EMAIL, {
+        email: req.email
+      });
+
+      return true;
+    }
+  },
+
+  Subscription: {
+    requestAlarmAdded: {
+      subscribe: withFilter(
+        (_, __, { pubsub }) => {
+          return pubsub.asyncIterator(REQUEST_ALARM_ADDED);
+        },
+        async (payload, _, { email }) =>
+          payload.requestAlarmAdded.targetEmail === email
+      )
+    }
+  }
+};


### PR DESCRIPTION
### 개발상황
- 친구 알람은 친구 요청, 알 수도 있는 사람으로 구성된다.
- graphql pub-sub을 통해 실시간으로 받은 '친구 요청 알람'을 해당 사람에게 보여준다. 
- 친구의 친구를 찾아서 추천 친구로서 '알 수도 있는 사람'에 보여준다.

### 질문/의견
context api를 많이 사용하면 코드가 복잡해지는 느낌이 듭니다. 하지만 자식에서 부모로 데이터를 넘겨야 할 경우, 부모로 대부분의 로직을 이동시키는 것과 큰 코드의 수정 없이 context api를 사용하는 것 둘 중 어떤 방식을 선호하시나요?