### PR TITLE
[Bug] 200/alarm click bugfix

### DIFF
--- a/server/src/api/feed/feed.resolvers.ts
+++ b/server/src/api/feed/feed.resolvers.ts
@@ -297,8 +297,8 @@ const queryResolvers: QueryResolvers = {
     const result = await requestDB(GET_FEED_ARALMS, {
       userEmail
     });
-    const [parsedAlarms] = parseResultRecords(result);
 
+    const [parsedAlarms] = parseResultRecords(result);
     return parsedAlarms.alarms;
   },
   alarmCount: async (_, __, { req }): Promise<number> => {


### PR DESCRIPTION
### 수정사항 
alarm click 시 댓글 알림 상세 보이지 않던 부분 수정 

### 작업사유
쿼리에서 댓글정보가 제대로 조회되지 않았고, 댓글의 경우 댓글이 작성된 feedId가 아닌 댓글의 Id 를 반환해서 생겼던 문제로
케이스를 구분하여 ID를 반환하도록 하고 댓글의 정보를 feed에 값과 맞춰서 반환하도로록 수정.