### PR TITLE
[feature-37] 바탕 클릭시 헤더 탭 리렌더링 막음 

### DIFF
--- a/client/src/composition/Header/HeaderTab.tsx
+++ b/client/src/composition/Header/HeaderTab.tsx
@@ -90,9 +90,15 @@ function HeaderTab() {
   }, [friendCount, headerTabCountDispatch]);
 
   const wrapperRef = useOutsideReset(() => {
-    headerTabDispatch({
-      type: 'INITSTATE'
-    });
+    if (
+      headerTabState.isActiveFriendTab ||
+      headerTabState.isActiveAlarmTab ||
+      headerTabState.isActiveMessageTab
+    ) {
+      headerTabDispatch({
+        type: 'INITSTATE'
+      });
+    }
   });
 
   return (


### PR DESCRIPTION
### 구현사항
알림 탭 외부 클릭시 닫히게 하려고 하는 부분 앞에서 조건처리함으로서
전역 상태 변화로 인한 리렌더링 방지